### PR TITLE
DataBlock fixes

### DIFF
--- a/data.go
+++ b/data.go
@@ -81,6 +81,9 @@ func (db *DataBlock) Bytes(dataType uint8, confirmed bool) []byte {
 		// Applying CRC mask, see DMR AI spec. page 143
 		db.CRC ^= 0x01ff
 
+		// Grow data slice to support the two byte prefix
+		data = append(data, make([]byte, 2)...)
+
 		data[0] = (db.Serial << 1) | (uint8(db.CRC>>8) & 0x01)
 		data[1] = uint8(db.CRC)
 		copy(data[2:], db.Data)

--- a/data_test.go
+++ b/data_test.go
@@ -19,7 +19,8 @@ func TestDataBlock(t *testing.T) {
 	if data == nil {
 		t.Fatal("encode failed")
 	}
-	size := int(dataBlockLength(Rate34Data, true))
+	// Size is the user-data + two octets of serial/crc
+	size := int(dataBlockLength(Rate34Data, true)) + 2
 	if len(data) != size {
 		t.Fatalf("encode failed: expected %d bytes, got %d", size, len(data))
 	}


### PR DESCRIPTION
Two patches to improve the Data Block and Fragment implementations.

Commit 2851102 is a bug fix related to data serialization, and commit b119727 fixes incorrect CRC masks for Rate 1/2 ~~and Rate 1 Data blocks~~.

Thanks!